### PR TITLE
Fix Vercel build path for static site

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Satayoo website with Next.js in static-site directory",
   "scripts": {
-    "dev": "cd static-site && npm run dev",
-    "build": "cd static-site && npm install && npm run build",
-    "start": "cd static-site && npm run start"
+    "dev": "npm run dev --prefix static-site",
+    "build": "npm install --prefix static-site && npm run build --prefix static-site",
+    "start": "npm run start --prefix static-site"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/static-site/vercel.json
+++ b/static-site/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "static-site/.next",
+  "outputDirectory": ".next",
   "installCommand": "npm install",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- delegate root scripts to the `static-site` folder
- move Vercel config into `static-site` and use local paths

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68affe8803dc83278606d6bd93a2fdab